### PR TITLE
docs(readme): add the ci, codecov and PRs-welcome shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # gnuplot.vim
 
+[![ci](https://img.shields.io/github/actions/workflow/status/dpezto/gnuplot.vim/ci.yml?branch=main&label=ci)](https://github.com/dpezto/gnuplot.vim/actions/workflows/ci.yml)
+[![codecov](https://img.shields.io/codecov/c/github/dpezto/gnuplot.vim)](https://codecov.io/gh/dpezto/gnuplot.vim)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](.github/CONTRIBUTING.md)
+
 Syntax highlighting for [gnuplot](http://www.gnuplot.info) 6 scripts.
 
 The keyword lists are generated from `keywords.json`, a pinned copy of the
@@ -90,12 +94,6 @@ machine written; the rest of the file is hand maintained.
 New keywords arrive on their own: a weekly job compares the vendored
 `keywords.json` against tree-sitter-gnuplot and opens a PR when it has moved,
 regenerating the syntax file with it.
-
-## Citation
-
-`CITATION.cff` carries the current version and release date. Both are written
-by release-please, so a `Cite this repository` on GitHub always matches the
-latest tag.
 
 ## Credits
 


### PR DESCRIPTION
Adds the three shields to the header:

- **ci** — `ci.yml` status on `main`
- **codecov** — see the caveat below
- **PRs welcome** — links to `.github/CONTRIBUTING.md`

Also drops the `## Citation` section. `CITATION.cff` still ships and
release-please still keeps its version and date current, so GitHub's
`Cite this repository` button is unaffected — the section only restated
what that button already shows.

### Caveat on the codecov shield

It will render `unknown` until something publishes coverage. `ci.yml` runs
the Vim/Neovim assertions but uploads nothing, and there is no codecov
configuration or token in the repository. Wiring up real coverage for VimL
means adding something like covimerage to the test matrix — happy to do it,
or to drop the shield, whichever you prefer.